### PR TITLE
Add Population to Location Event

### DIFF
--- a/docs/Travel.md
+++ b/docs/Travel.md
@@ -451,6 +451,7 @@ Parameters:
 - SystemSecondEconomy 
 - SystemGovernment 
 - SystemSecurity 
+- Population
 - Wanted 
 - Factions: an array with info on local minor factions (similar to FSDJump) 
 - Conflicts: an array with info on local conflicts (similar to FSDJump) 


### PR DESCRIPTION
I was surprised to see that `Location` didn't have a `Population` at first, luckily my journals have that field for this event.