### PR TITLE
Add B_BlueWhiteSuperGiant to Star Descriptions in Appendix

### DIFF
--- a/docs/Appendix.md
+++ b/docs/Appendix.md
@@ -139,6 +139,7 @@ _**Exobiologist Ranks**_:
 - X (=_exotic_)
 - SupermassiveBlackHole
 - A_BlueWhiteSuperGiant
+- B_BlueWhiteSuperGiant
 - F_WhiteSuperGiant
 - M_RedSuperGiant
 - M_RedGiant


### PR DESCRIPTION
I noticed that the "B_BlueWhiteSuperGiant" StarType is missing from the Appendix, while I was cross-referencing StarTypes from my database and what kind of StarTypes are available.

Maybe it's missing due to slight oversight, maybe it's not there for some other reason. :)

![image](https://github.com/user-attachments/assets/52d30319-393f-4694-9267-e014bb241f11)
